### PR TITLE
:wrench: Changed repo to AppCenter

### DIFF
--- a/src/include/sysroot/usr/bin/install-epiphany.sh
+++ b/src/include/sysroot/usr/bin/install-epiphany.sh
@@ -10,5 +10,5 @@ echo "Installing Epiphany..."
 sodalite-install-appcenter-flatpak
 flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
 
-flatpak install --noninteractive --or-update --system flathub org.freedesktop.Platform.GL.default//21.08
+flatpak install --noninteractive --or-update --system appcenter org.freedesktop.Platform.GL.default//21.08
 flatpak install --noninteractive --or-update --system appcenter org.gnome.Epiphany//stable


### PR DESCRIPTION
org.freedesktop.Platform.GL.default is provided by the AppCenter repo. Due to this, the Flathub repo is technically not needed here. For the sake of consistency, I have changed it to using the AppCenter repo.